### PR TITLE
Make ctrack and conjuror available on command line

### DIFF
--- a/bin/conjuror
+++ b/bin/conjuror
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+
+"use strict";
+var path = require('path');
+var fs = require('fs');
+var root = path.join(path.dirname(fs.realpathSync(__filename)), '../');
+
+require(root+'/conjuror.js');

--- a/bin/ctrack
+++ b/bin/ctrack
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+
+"use strict";
+var path = require('path');
+var fs = require('fs');
+var root = path.join(path.dirname(fs.realpathSync(__filename)), '../');
+
+require(root+'/track.js');

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "conjuror",
   "description": "A magical CSV data parsing and outputing wizard or witch",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "repository": {
     "url": "https://github.com/bnvk/Conjuror"
   },
-  "main": "./lib/",
+  "main": "./conjuror",
   "keywords": [
     "time tracking",
     "time management",
@@ -13,7 +13,8 @@
     "pdf"
   ],
   "bin": {
-    "conjuror": "./bin/uppercaseme"
+    "conjuror": "./bin/conjuror",
+    "ctrack": "./bin/ctrack"
   },
   "author": "Brennan Novak <hi@bnvk.me>",
   "contributors": [
@@ -23,6 +24,7 @@
     "argv": "0.0.2",
     "bootstrap": "^3.3.2",
     "cheerio": "*",
+    "csv": "^0.4.1",
     "es6-promise": "^2.0.1",
     "fs": "*",
     "inquirer": "*",
@@ -34,7 +36,7 @@
     "node": "*"
   },
   "devDependencies": {
-    "csv": "^0.4.1"
+    "mocha":"^2.2.5"
   },
   "bugs": {
     "url": "https://github.com/bnvk/Conjuror/issues"

--- a/track.js
+++ b/track.js
@@ -18,7 +18,15 @@ argv.option({
   short: 'i',
   type: 'string',
   description: 'Defines a CSV file for you to open',
-  example: "'track.js --input=value' or 'track.js -s data/work.csv"
+  example: "'track.js --input=value' or 'track.js -i data/work.csv"
+});
+
+argv.option({
+  name: 'timer',
+  short: 't',
+  type: 'boolean',
+  description: 'Times instead of direct implementation',
+  example: "'track.js --timer -i data/work.csv' or track.js -t -i data/work/csv"
 });
 
 


### PR DESCRIPTION
Basically just finalize the work @bnvk started to make this a bin thing. 

```
$ npm install -g conjuror
$ conjuror
> 404 No spell found 
> Are you sure you specified an --input -i value
$ conjuror -i ~/src/conjuror/data/hours.json
> Spits out hours.json
```

* `ctrack` is track. 
* `conjuror` is the conjuror. 

Use as normal. This might be a time to do a home conjuror folder with all the data.

## Next:

* Automatically run setup on running conjuror for the first time?
* Automatically create to default `client.csv` and `hours.csv` for the purpose of tracking when running conjuror for the first time or setup?